### PR TITLE
fix issue #2

### DIFF
--- a/src/views/home.vue
+++ b/src/views/home.vue
@@ -1,4 +1,5 @@
 <template>
+<div>
 <div class="content home" action="refresh" distance="55" v-pull-to-refresh>
   <v-layer></v-layer>
   <slider :imgs="slider.imgs" :config="slider.config"></slider>
@@ -45,6 +46,7 @@
       </card>
     </v-card-container>
   </div>
+</div>
 </div>
 </template>
 


### PR DESCRIPTION
修复issue #2。

当sui的pull-to-refresh元素拉长到小于刷新长度，再放开，此时sui会给该元素加上一个class：`transitioning`。
然后根据`sm.css`，此时该元素有css：
```
.pull-to-refresh-content.transitioning {
    -webkit-transition: -webkit-transform .4s;
    transition: transform .4s;
}
```

而当点击导航时，根据vue的过渡（transition）会给过渡元素加上一个class：`fade-transtion`。
再根据你写的css（在main.vue里），则该元素有css：
```
.fade-transition {
  transition: opacity .3s ease;
}
```

也就是说，一个元素，同时拥有`transition: opacity .3s ease`和 `transition: transform .4s`。
结果就是vue的过渡进行到`fade-leave`的时候，`transition: opacity .3s ease`就被顶掉了，于是opacity不能进行动画，就一直保持着`opacity: 0`的状态。

解决方法：把`pull-to-refresh`元素和vue带有`transition`的元素分开，别让它们是同一个元素。